### PR TITLE
re-expose connection status and control from inner client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 name = "mc-rpc"
 version = "0.1.1"
 dependencies = [
+ "futures-util",
  "pale",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ pale = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 serde_json = "1.0"
+futures-util = "0.3.31"
 
 [build-dependencies]
 serde_json = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -58,8 +58,10 @@ pub fn generate(schema: &Value) -> Option<String> {
 
 fn dependencies() -> &'static str {
     r#"
+use std::{result::Result as StdResult, time::Duration};
 use serde::{Deserialize, Serialize};
-use tokio_stream::Stream;
+use futures_util::TryStreamExt as _;
+use tokio_stream::{Stream, wrappers::{BroadcastStream, errors::BroadcastStreamRecvError}};
 pub use pale::{ClientConfig, Result, PaleError, RPCError, StreamExt, WebSocketConfig};"#
 }
 
@@ -74,6 +76,49 @@ impl Client {0}
     pub async fn new(uri: impl AsRef<str>, config: ClientConfig) -> Result<Self> {0}
         Ok(Self(pale::Client::new(uri, config).await?))
     {1}
+
+    /// Calling [`Self::close`] means:
+    /// - Closing the underlying connection.
+    /// - Any and all internal client communication
+    /// - Closing every subscription stream
+    ///
+    /// The [`Client`] is not guaranteed to be 100% closed after this function returns.
+    /// It may take a little while, use [`Self::wait_for_connection`] to make sure before, let's say reconnecting.
+    pub async fn close(&self) -> Result<()> {0}
+        self.0.close().await
+    {1}
+
+    /// Returns if the underlying socket is actively connected.
+    pub async fn is_connected(&self) -> bool {0}
+        self.0.is_connected().await
+    {1}
+
+    /// Returns when the [`Self::is_connected`] is equal to `state`
+    ///
+    /// If [`Self::is_connected`] already matches `state`, it instantly returns
+    ///
+    /// ## Example
+    /// ```no_run
+    /// // waits for the underlying connection to be ready & connected
+    /// client.wait_for_connection(true, Duration::from_secs(5)).await;
+    ///
+    /// // waits for the connection to disconnect
+    /// client.wait_for_connection(false, Duration::from_secs(5)).await;
+    /// ```
+    pub async fn wait_for_connection(&self, state: bool, timeout_duration: Duration) -> Result<()> {0}
+        self.0.wait_for_connection(state, timeout_duration).await
+    {1}
+
+    /// Returns a [`Stream`] where a message of type [`Client`] will be sent upon each successful reconnection.
+    pub fn on_reconnect(&self) -> impl Stream<Item = StdResult<Self, BroadcastStreamRecvError>> {0}
+        BroadcastStream::new(self.0.on_reconnect()).map_ok(Self)
+    {1}
+
+    /// Returns a [`Stream`] where a message of type [`Client`] will be sent upon disconnect.
+    pub fn on_disconnect(&self) -> impl Stream<Item = StdResult<Self, BroadcastStreamRecvError>> {0}
+        BroadcastStream::new(self.0.on_disconnect()).map_ok(Self)
+    {1}
+
 {1}"#,
         CURLY[0], CURLY[1]
     )


### PR DESCRIPTION
I found myself wanting this information, so I added some methods to bubble it up from the inner client. Thanks for making this!