### PR TITLE
hard code indent character for schema to help bad diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ version = "0.1.0"
 dependencies = [
  "dotenvy",
  "pale",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/schema_fetch/Cargo.toml
+++ b/schema_fetch/Cargo.toml
@@ -8,3 +8,4 @@ pale = "0.1.0"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0"
 dotenvy = "0.15.7"
+serde = "1.0.228"

--- a/schema_fetch/src/main.rs
+++ b/schema_fetch/src/main.rs
@@ -1,9 +1,9 @@
-use serde::ser::Serialize;
-use std::fs::File;
-
 use pale::{Client, ClientConfig, Result};
+use serde::ser::Serialize;
 use serde_json::ser::PrettyFormatter;
 use serde_json::{Serializer, Value};
+use std::fs::File;
+use std::io::BufWriter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,7 +17,9 @@ async fn main() -> Result<()> {
     let schema: Value = client.request("rpc.discover", None).await?;
     let formatter = PrettyFormatter::with_indent(b"    ");
     let mut serializer = Serializer::with_formatter(
-        File::create(concat!(env!("CARGO_MANIFEST_DIR"), "/../schema.json")).unwrap(),
+        BufWriter::new(
+            File::create(concat!(env!("CARGO_MANIFEST_DIR"), "/../schema.json")).unwrap(),
+        ),
         formatter,
     );
     schema

--- a/schema_fetch/src/main.rs
+++ b/schema_fetch/src/main.rs
@@ -1,7 +1,9 @@
-use std::fs::write;
+use serde::ser::Serialize;
+use std::fs::File;
 
 use pale::{Client, ClientConfig, Result};
-use serde_json::Value;
+use serde_json::ser::PrettyFormatter;
+use serde_json::{Serializer, Value};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -13,10 +15,13 @@ async fn main() -> Result<()> {
     )
     .await?;
     let schema: Value = client.request("rpc.discover", None).await?;
-
-    let json = serde_json::to_string_pretty(&schema)?;
-
-    write(concat!(env!("CARGO_MANIFEST_DIR"), "/../schema.json"), json)
+    let formatter = PrettyFormatter::with_indent(b"    ");
+    let mut serializer = Serializer::with_formatter(
+        File::create(concat!(env!("CARGO_MANIFEST_DIR"), "/../schema.json")).unwrap(),
+        formatter,
+    );
+    schema
+        .serialize(&mut serializer)
         .expect("Failed to write new schema.json file");
 
     Ok(())


### PR DESCRIPTION
This is an extremely minor change. I just noticed that the existing `schema.json` uses 4 spaces to indent rather than the two generated by the script. This PR specifies the preference for 4 spaces so that it's easier to diff the schema after a generation.